### PR TITLE
Fix to the Issue#7

### DIFF
--- a/js/adapt-contrib-background-switcher.js
+++ b/js/adapt-contrib-background-switcher.js
@@ -19,6 +19,10 @@ define([
 			this._blockModels = this.model.findDescendants('blocks').filter(function(model) {
 				return model.get("_backgroundSwitcher");
 			});
+			if(this._blockModels.length == 0) {
+			        this.onRemove();
+			        return;
+			}
 			this._blockModelsIndexed = _.indexBy(this._blockModels, "_id");
 
 			this.listenTo(Adapt, "pageView:ready", this.onPageReady);


### PR DESCRIPTION
When there are no blocks with `_backgroundSwitcher` and it is turned on for that page the extension thrown error, this prevents this situations by checking if there are any blocks if not exits and calls `onRemove`.