### PR TITLE
IE and Edge Fixed Image Scroll Issue

### DIFF
--- a/less/background-switcher.less
+++ b/less/background-switcher.less
@@ -80,6 +80,14 @@
     @media all and (max-width:699px){
         .background-switcher-mobile;
     }
-    
-
 }
+
+html{
+    overflow: hidden;
+    height: 100%;    
+}
+body{
+    overflow: auto;
+    height: 100%;
+}
+


### PR DESCRIPTION
Microsoft browsers make fixed backgrounds jump when scrolling with the mouse wheel. I'm not sure if modifying the main tags are something that is desirable, but I found this to be a helpful fix.